### PR TITLE
Revert cloaked unit patch and sync log name change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ EXE_OBJS = \
 		src/graphics-patch.o \
 		src/copy-protection.o \
 		src/multi_spectators_hack.o \
-		src/cloaked_patches.o \
+		# src/cloaked_patches.o 
 		src/absolute_prism_bug_fix.o \
 		src/self_spy_exploit_fix.o \
 		src/invisible_mcv_exploit_fix.o \
@@ -57,7 +57,7 @@ DLL_OBJS = src/ares.o \
 		src/mods/saved_games_in_subdir.o \
 		src/loading_dll.o \
 		src/multi_spectators_hack.o \
-		src/cloaked_patches.o \
+		# src/cloaked_patches.o
 		src/fix_mouse_not_found_error.o \
 		src/video_mode_hack.o \
 		src/type_select_hacks.o \

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ EXE_OBJS = \
 		src/graphics-patch.o \
 		src/copy-protection.o \
 		src/multi_spectators_hack.o \
-		# src/cloaked_patches.o 
 		src/absolute_prism_bug_fix.o \
 		src/self_spy_exploit_fix.o \
 		src/invisible_mcv_exploit_fix.o \
@@ -57,7 +56,6 @@ DLL_OBJS = src/ares.o \
 		src/mods/saved_games_in_subdir.o \
 		src/loading_dll.o \
 		src/multi_spectators_hack.o \
-		# src/cloaked_patches.o
 		src/fix_mouse_not_found_error.o \
 		src/video_mode_hack.o \
 		src/type_select_hacks.o \

--- a/src/rename_logs.asm
+++ b/src/rename_logs.asm
@@ -2,8 +2,8 @@
 %include "macros/datatypes.inc"
 
 sstring str_except, "EXCEPT_CNCNET.TXT"
-sstring str_sync1, "SYNC_CNCNET%01d.TXT"
-sstring str_sync2, "SYNC_CNCNET%01d_%03d.TXT"
+sstring str_sync1, "SYNC%01d.TXT"
+sstring str_sync2, "SYNC%01d_%03d.TXT"
 
 @SET 0x004C901C, {push str_except}
 @SET 0x0064DEC4, {push str_sync1}

--- a/src/rename_logs.asm
+++ b/src/rename_logs.asm
@@ -2,9 +2,9 @@
 %include "macros/datatypes.inc"
 
 sstring str_except, "EXCEPT_CNCNET.TXT"
-sstring str_sync1, "SYNC%01d.TXT"
-sstring str_sync2, "SYNC%01d_%03d.TXT"
+; sstring str_sync1, "SYNC_CNCNET%01d.TXT"
+; sstring str_sync2, "SYNC_CNCNET%01d_%03d.TXT"
 
 @SET 0x004C901C, {push str_except}
-@SET 0x0064DEC4, {push str_sync1}
-@SET 0x00651716, {push str_sync2}
+; @SET 0x0064DEC4, {push str_sync1}
+; @SET 0x00651716, {push str_sync2}


### PR DESCRIPTION
- Changes `SYNC_CNCNET_*` to `SYNC*`
- Revert cloaked unit patch, possibly causing recons