### PR TITLE
Adds option to disable in-game chat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ EXE_OBJS = \
 		src/loading.o \
 		src/graphics-patch.o \
 		src/copy-protection.o \
+		src/chat_disable.o \
 		src/multi_spectators_hack.o \
 		src/absolute_prism_bug_fix.o \
 		src/self_spy_exploit_fix.o \
@@ -75,6 +76,7 @@ SPAWNER_OBJS = \
 		src/custom_connection_timeout.o \
 		src/Hook_Main_Loop.o \
 		src/spawner/add_player_node.o \
+		src/spawner/chat_ignore.o \
 		src/spawner/coop.o \
 		src/spawner/load_spawn.o \
 		src/spawner/predetermined_alliances.o \

--- a/inc/HouseClass.h
+++ b/inc/HouseClass.h
@@ -21,10 +21,15 @@ typedef struct HouseTypeClass_vtable {
     int (__thiscall *Read_INI)(HouseType *houseType, INIClass *ini);
 } HouseTypeClass_vtable;
 
+// Size = 0x160b8
+#pragma pack(push, 1)
 typedef struct HouseClass {
     char gap[0x30];
     int ArrayIndex;
+    char gap2[0x15ff6];
+    wchar_t UIName[21];
 } HouseClass;
+#pragma pack(pop)
 
 extern HouseClass *PlayerPtr;
 HouseType **HouseTypeClassArray;

--- a/inc/RA.h
+++ b/inc/RA.h
@@ -22,6 +22,7 @@ extern bool QuickMatch;
 extern bool RunAutoSS;
 extern bool DoingAutoSS;
 extern bool UsePNG;
+extern bool DisableChat;
 
 void *new(int32_t size);
 void __thiscall ScenarioClass_ReadLightingAndBasic(void *this, void *ini);
@@ -43,5 +44,5 @@ void __thiscall ScreenCaptureCommandClass_Execute();
 typedef void MessageListClass;
 extern MessageListClass *MessageListClass_this;
 void __thiscall MessageListClass__Manage(MessageListClass *message_list);
-void __thiscall MessageListClass__Add_Message(MessageListClass *this, const wchar_t *Name, int ID,
-                                              const wchar_t *message, int color, int32_t PrintType, int32_t duration, bool SinglePlayer);
+void* __thiscall MessageListClass__Add_Message(MessageListClass *this, const wchar_t *Name, int ID,
+                                               const wchar_t *message, int color, int32_t PrintType, int32_t duration, bool SinglePlayer);

--- a/inc/SessionClass.h
+++ b/inc/SessionClass.h
@@ -3,6 +3,7 @@ typedef struct SessionClass {
 } SessionClass;
 
 extern SessionClass SessionClass_this;
+extern bool SessionClass_ChatEnabled[8];
 
 void __thiscall SessionClass__Read_Scenario_Descriptions(SessionClass *this);
 void __thiscall SessionClass__Create_Connections(SessionClass *this);

--- a/inc/macros/helpers.h
+++ b/inc/macros/helpers.h
@@ -1,0 +1,1 @@
+#define countof(x) sizeof(x)/sizeof(*x)

--- a/src/Hook_Main_Loop.c
+++ b/src/Hook_Main_Loop.c
@@ -1,4 +1,5 @@
 #include "macros/patch.h"
+#include "macros/helpers.h"
 #include "RA.h"
 #include "SessionClass.h"
 #include "network.h"
@@ -41,6 +42,17 @@ MainLoop_AfterRender(void *message_list)
             ResponseTimeFrame = Frame + ResponseTimeInterval;
             Send_Response_Time();
         }
-    }
 
+        /* Disable "ENTER" chat for all users. Grey out the "Chat" checkbox in alliances menu.
+           TODO: This is redundant because patches in chat_disable.asm already prevent sending all message types.
+           This exists mainly for cosmetic purposes. A better solution would be to patch the function responsible for
+           toggling the chat checkbox. */
+        if (DisableChat)
+        {
+            for (int i = 0; i < countof(SessionClass_ChatEnabled); i++)
+            {
+                SessionClass_ChatEnabled[i] = false;
+            }
+        }
+    }
 }

--- a/src/chat_disable.asm
+++ b/src/chat_disable.asm
@@ -1,0 +1,24 @@
+%include "macros/patch.inc"
+%include "macros/datatypes.inc"
+
+cextern DisableChat
+
+; Don't send message to others.
+hack 0x0055EF38, 0x0055EF3E
+    cmp byte[DisableChat], 0
+    jz  .Reg
+    jmp 0x0055F056
+
+.Reg:
+    cmp edi, ebx
+    mov dword[esp + 0x14], ebx
+    jmp hackend
+
+; After receiving message, don't play sound if AddMessage returns NULL.
+hack 0x0048D97E
+    cmp eax, 0
+    je 0x0048D99A
+
+.Reg:
+    mov eax, [0x008871E0]
+    jmp hackend

--- a/src/loading.c
+++ b/src/loading.c
@@ -10,6 +10,7 @@
 #include "macros/patch.h"
 
 #include "INIClass.h"
+#include "RA.h"
 
 CALL(0x006BC0DC, _read_extra_options);
 
@@ -64,6 +65,7 @@ read_extra_options(INIClass *old_INI, const char *section, const char *key, bool
         Win8Compat              = INIClass__GetBool(&RA2md_INI, "Options", "Win8Compat", false);
 
         SingleProcAffinity      = INIClass__GetBool(&RA2md_INI, "Options", "SingleProcAffinity", true);
+        DisableChat             = INIClass__GetBool(&RA2md_INI, "Options", "DisableChat", false);
         SetSingleProcAffinity();
 
         HMODULE hDDraw = LoadLibraryA("ddraw.dll");

--- a/src/spawner/chat_ignore.c
+++ b/src/spawner/chat_ignore.c
@@ -1,0 +1,33 @@
+#include <wchar.h>
+
+#include "HouseClass.h"
+#include "RA.h"
+#include "macros/patch.h"
+
+CALL(0x48d979, _fake_MessageListClass__Add_Message);
+CALL(0x55f0f5, _fake_MessageListClass__Add_Message);
+
+bool DisableChat = false;
+
+void *__thiscall fake_MessageListClass__Add_Message(MessageListClass *this,
+                                                    const wchar_t *Name,
+                                                    int ID,
+                                                    const wchar_t *message,
+                                                    int color,
+                                                    int32_t PrintType,
+                                                    int32_t duration,
+                                                    bool SinglePlayer)
+{
+    if (!DisableChat || Name == NULL)
+    {
+        return MessageListClass__Add_Message(this, Name, ID, message, color, PrintType, duration, SinglePlayer);
+    }
+
+    if (wcsicmp(Name, PlayerPtr->UIName) == 0)
+    {
+        return MessageListClass__Add_Message(this, 0, 0, L"Chat is disabled. Message not sent.", 4, 0x4096, 270, 1);
+    }
+
+    /* Base case. Don't display incoming player messages. */
+    return NULL;
+}

--- a/src/spawner/load_spawn.c
+++ b/src/spawner/load_spawn.c
@@ -269,6 +269,8 @@ signed int Initialize_Spawn()
         RunAutoSS  =     INIClass__GetBool(&INIClass_SPAWN, "Settings", "RunAutoSS", false);
         ConnTimeout =    INIClass__GetInt(&INIClass_SPAWN, "Settings", "ConnTimeout", 3600);
         ReconnectTimeout=INIClass__GetInt(&INIClass_SPAWN, "Settings", "ReconnectTimeout", 2400);
+        if (!DisableChat)
+            DisableChat = INIClass__GetBool(&INIClass_SPAWN, "Settings", "DisableChat", false);
 
         INIClass__GetString(&INIClass_SPAWN, "Settings", "MapHash", "", MapHash, 255);
         INIClass__GetString(&INIClass_SPAWN, "Settings", "UIMapName", "", UIMapName, 255);

--- a/src/spawner/protocol_zero.asm
+++ b/src/spawner/protocol_zero.asm
@@ -15,7 +15,7 @@ hack 0x00647BEB, 0x00647BF4           ;Queue_AI_Multiplayer
     jmp hackend
 
 ; Don't subtract 10 from MaxAhead
-hack 0x004C800C,                       ;EventClass::Execute->TIMING
+hack 0x004C800C                       ;EventClass::Execute->TIMING
     mov eax,[0x00A8B230] ; Scenario
 
     cmp byte[UseProtocolZero], 0

--- a/sym.asm
+++ b/sym.asm
@@ -27,6 +27,7 @@ setcglob 0x007E1280, _imp__GetCommandLineA
 setcglob 0x007E1460, _imp__MessageBoxA
 setcglob 0x004C8FE0, PrintException
 setcglob 0x007CA489, wcscpy
+setcglob 0x007DD0F8, wcsicmp
 setcglob 0x007E11F0, _imp__Sleep
 setcglob 0x007E13EC, _imp__GetSystemMetrics
 
@@ -159,6 +160,7 @@ setcglob 0x00A8B26C, MultiEngineer
 setcglob 0x00A8B394, PlayerColor
 setcglob 0x00A8B23C, GameMode
 setcglob 0x008871E0, RulesData
+setcglob 0x00A8D108, SessionClass_ChatEnabled
 
 setcglob 0x0061f210, Game_LoadPCXFiles
 setcglob 0x00600560, InitCommonDialogStuff


### PR DESCRIPTION
Addresses issue #7

Adds option to disable in-game chat. If `DisableChat=True`, the player cannot send or receive messages from others. The option can be set in spawn.ini (under "Settings" section) and RA2MD.ini (under "Options" section). Enabling the option in spawn.ini overrides the setting in RA2MD.ini even if explicitly set to `False`.