### PR TITLE
Support writing logs to Git-Bash mintty terminal; reduce the number of "GetStdHandle()" calls

### DIFF
--- a/src/yr_util.c
+++ b/src/yr_util.c
@@ -41,7 +41,9 @@ hook_wwdebug_printf(char const *fmt, ...)
     return;
   LPDWORD ret;
 
-  WriteConsole(h,wwdebug_buf,len, 0, 0);
+  // In some terminals (e.g., mintty from Git-Bash), "WriteConsole(h, ...)"
+  //   writes NOTHING because "GetFileType(h) == FILE_TYPE_PIPE".
+  WriteFile(h,wwdebug_buf,len, 0, 0);
   return;
 }
 

--- a/src/yr_util.c
+++ b/src/yr_util.c
@@ -20,14 +20,14 @@ hook_wwdebug_printf(char const *fmt, ...)
   va_list ap;
   va_start(ap,fmt);
   static bool already_consoled = false;
+  static HANDLE h = 0;
 
   if (!already_consoled) {
     AllocConsole();
     already_consoled = true;
+    h = GetStdHandle(STD_OUTPUT_HANDLE);
     WWDebug_Printf("Allocated the console\n");
   }
-
-  HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
 
   size_t fmt_len = strnlen(fmt,99);
 

--- a/sym.asm
+++ b/sym.asm
@@ -13,7 +13,7 @@ setcglob 0x004068E0, WWDebug_Printf
 setcglob 0x00A8ED6B, Debug_Map
 
 setcglob 0x007E12CC, _imp__GetStdHandle
-setcglob 0x007E1344, _imp__WriteConsoleA
+setcglob 0x007E11A0, _imp__WriteFile
 setcglob 0x007E1218, _imp__AllocConsole
 setcglob 0x007E11A8, _imp__GetModuleFileNameA
 setcglob 0x007E11A4, _imp__GetCurrentProcess_hack


### PR DESCRIPTION
Hello!

In some terminals (e.g., mintty from Git-Bash), `WriteConsole(h, ...)` writes NOTHING because `GetFileType(h)` is `FILE_TYPE_PIPE` instead of `FILE_TYPE_CHAR`. I don't know the exact reason, but switching to `WriteFile(h, ...)` does solve the issue and does not break anything if it's in other terminals (e.g., conhost.exe or Windows Terminal - they are `FILE_TYPE_CHAR`).

Please test my changes.

My test video:

https://github.com/user-attachments/assets/1f39c553-ec51-4ffc-ad13-42bee2d63455

Test environment:

- Windows 11 10.0.26100.1742
- mintty '3.7.7' de5cc9f8 of Git-Bash from Git 2.49.0

.


