### PR TITLE
Add option to hide FPS slider via spawn.ini setting

### DIFF
--- a/FPS_SLIDER_HIDE_USAGE.md
+++ b/FPS_SLIDER_HIDE_USAGE.md
@@ -1,0 +1,41 @@
+# FPS Slider Hide Patch Usage Example
+
+## Overview
+The FPS Slider Hide patch allows game hosts to control whether the FPS/gamespeed slider is visible in the in-game pause menu. This is useful for tournament play or preventing players from adjusting game speed during matches.
+
+## Configuration
+
+Add the following setting to your `spawn.ini` file under the `[Settings]` section:
+
+```ini
+[Settings]
+# Hide the FPS/gamespeed slider from the in-game menu
+HideFPSSlider=yes
+
+# Or to show the slider (default behavior)
+HideFPSSlider=no
+```
+
+## Example spawn.ini
+
+```ini
+[Settings]
+HideFPSSlider=yes    # This line hides the FPS slider
+```
+
+## Behavior
+
+- When `HideFPSSlider=yes`: The FPS/gamespeed slider will not appear in the in-game pause menu
+- When `HideFPSSlider=no` or not specified: The slider will appear normally (default behavior)
+
+## Technical Details
+
+This patch is a local UI modification that:
+- Does not affect networking or multiplayer synchronization
+- Only controls the visibility of the slider in the pause menu
+- Is loaded from spawn.ini during game initialization
+- Works independently of other game settings
+
+## Note
+
+This setting is read from the spawn.ini file when the game is launched. The setting only affects the visibility of the slider in the in-game menu during gameplay, not the actual FPS cap or performance settings.

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ SPAWNER_OBJS = \
 		src/spawner/selectable_handicaps.o \
 		src/spawner/selectable_spawns.o \
 		src/spawner/skip_score.o \
-		src/spawner/spectators.o
+		src/spawner/spectators.o \
+		src/hide_fps_slider.o
 
 ifndef CNCNET
 	SPAWNER_OBJS += src/spawner/nethack.o

--- a/inc/RA.h
+++ b/inc/RA.h
@@ -23,6 +23,7 @@ extern bool RunAutoSS;
 extern bool DoingAutoSS;
 extern bool UsePNG;
 extern bool DisableChat;
+extern bool HideFPSSlider;
 
 void *new(int32_t size);
 void __thiscall ScenarioClass_ReadLightingAndBasic(void *this, void *ini);

--- a/src/hide_fps_slider.asm
+++ b/src/hide_fps_slider.asm
@@ -1,0 +1,40 @@
+%include "macros/patch.inc"
+%include "macros/hack.inc"
+%include "macros/datatypes.inc"
+%include "session.inc"
+
+; Hide FPS/Gamespeed Slider from in-game menu based on spawn.ini setting
+; =====================================================================
+; This patch allows control over the FPS/gamespeed slider visibility in the pause/in-game menu
+;
+; Usage:
+; Add the following line to the [Settings] section of spawn.ini:
+; HideFPSSlider=yes     ; Hide the FPS/gamespeed slider from in-game menu
+; HideFPSSlider=no      ; Show the FPS/gamespeed slider (default)
+;
+; When HideFPSSlider=yes, the slider will be hidden from the pause menu during gameplay.
+; This is useful for tournament play or when you want to prevent players from adjusting
+; the game speed during matches.
+;
+; Note: This patch works in conjunction with the spectators.asm patch and should be
+; applied after it in the build order.
+
+cextern HideFPSSlider
+
+; Override the existing gamespeed slider logic to also check our HideFPSSlider setting
+; We patch at a point after the spectators check but before slider display
+@HACK 0x004E20C0, _Hide_FPS_Slider_InGame_Menu_Override
+    ; First check our HideFPSSlider setting
+    cmp byte[HideFPSSlider], 1
+    jz .HideSlider
+
+    ; If not hiding, continue with normal execution (including spectator logic)
+    ; This is the instruction that would normally execute after the spectators patch
+    mov eax, dword [0x00A8B538]
+    test eax, eax
+    jmp 0x004E20C5
+
+.HideSlider:
+    ; Hide the slider by jumping past the display code
+    jmp 0x004E211A
+@ENDHACK

--- a/src/spawner/load_spawn.c
+++ b/src/spawner/load_spawn.c
@@ -185,6 +185,7 @@ int32_t ReconnectTimeout;
 bool QuickMatch = false;
 bool Ra2Mode = false;
 bool     RunAutoSS;
+bool HideFPSSlider = false;
 
 
 int __fastcall InitGame(int argc, char **argv);
@@ -267,6 +268,7 @@ signed int Initialize_Spawn()
             MPSYNCDEBUG = MPDEBUG1 = MPDEBUG = false;
 
         RunAutoSS  =     INIClass__GetBool(&INIClass_SPAWN, "Settings", "RunAutoSS", false);
+        HideFPSSlider =  INIClass__GetBool(&INIClass_SPAWN, "Settings", "HideFPSSlider", false);
         ConnTimeout =    INIClass__GetInt(&INIClass_SPAWN, "Settings", "ConnTimeout", 3600);
         ReconnectTimeout=INIClass__GetInt(&INIClass_SPAWN, "Settings", "ReconnectTimeout", 2400);
         if (!DisableChat)


### PR DESCRIPTION
WIP: First time doing something like this from scratch. Not simple rename. Be very cautious on merging / approving.

Introduces a new HideFPSSlider setting in spawn.ini to control the visibility of the FPS/gamespeed slider in the in-game pause menu.

Updates include a new ASM patch to conditionally hide the slider, Makefile changes to include the patch, and documentation for usage.

This is useful for tournament play or restricting in-game speed adjustments.