### PR TITLE
Add option to hide FPS slider in in-game menu

### DIFF
--- a/inc/RA.h
+++ b/inc/RA.h
@@ -23,6 +23,7 @@ extern bool RunAutoSS;
 extern bool DoingAutoSS;
 extern bool UsePNG;
 extern bool DisableChat;
+extern bool HideFPSSlider;
 
 void *new(int32_t size);
 void __thiscall ScenarioClass_ReadLightingAndBasic(void *this, void *ini);

--- a/src/hide_fps_slider.asm
+++ b/src/hide_fps_slider.asm
@@ -1,0 +1,24 @@
+%include "macros/patch.inc"
+%include "macros/hack.inc"
+%include "macros/datatypes.inc"
+%include "session.inc"
+
+; Hide FPS/Gamespeed Slider from in-game menu based on spawn.ini setting
+; This patch allows control over the FPS/gamespeed slider visibility in the pause/in-game menu
+;
+; Note: This patch works in conjunction with the spectators.asm patch and should be
+; applied after it in the build order.
+
+cextern HideFPSSlider
+
+@HACK 0x004E20C0, _Hide_FPS_Slider_InGame_Menu_Override
+    cmp byte[HideFPSSlider], 1
+    jz .HideSlider
+
+    mov eax, dword [0x00A8B538]
+    test eax, eax
+    jmp 0x004E20C5
+
+.HideSlider:
+    jmp 0x004E211A
+@ENDHACK

--- a/src/spawner/load_spawn.c
+++ b/src/spawner/load_spawn.c
@@ -185,6 +185,7 @@ int32_t ReconnectTimeout;
 bool QuickMatch = false;
 bool Ra2Mode = false;
 bool     RunAutoSS;
+bool HideFPSSlider = false;
 
 
 int __fastcall InitGame(int argc, char **argv);
@@ -267,6 +268,7 @@ signed int Initialize_Spawn()
             MPSYNCDEBUG = MPDEBUG1 = MPDEBUG = false;
 
         RunAutoSS  =     INIClass__GetBool(&INIClass_SPAWN, "Settings", "RunAutoSS", false);
+        HideFPSSlider =  INIClass__GetBool(&INIClass_SPAWN, "Settings", "HideFPSSlider", false);
         ConnTimeout =    INIClass__GetInt(&INIClass_SPAWN, "Settings", "ConnTimeout", 3600);
         ReconnectTimeout=INIClass__GetInt(&INIClass_SPAWN, "Settings", "ReconnectTimeout", 2400);
         if (!DisableChat)


### PR DESCRIPTION
Note: 
This should be taken with scrutiny. Should be verified or vetted before any merge or approval.
PR'ing into main to use nightly build for testing.


Introduces the HideFPSSlider variable and associated logic to conditionally hide the FPS/gamespeed slider in the in-game menu based on a spawn.ini setting.

Includes a new assembly patch and updates to configuration loading to support this feature.